### PR TITLE
more testing and created feedback messages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,29 +1,3 @@
-// import logo from './logo.svg';
-// import './App.css';
-// import HotCakes from "./components/Hotcakes"
-
-// function App() {
-//   return ( 
-//     <div className="App">
-//       <header className="App-header">
-//         <img src={logo} className="App-logo" alt="logo" />
-//         <p>
-//           Edit <code>src/App.js</code> and save to reload.
-//         </p>
-//         <a
-//           className="App-link"
-//           href="https://reactjs.org"
-//           target="_blank"
-//           rel="noopener noreferrer"
-//         >
-//           Learn React
-//         </a>
-//       </header>
-//     </div>
-//   );
-// }
-
-// export default App;
 
 import { Route, Routes } from "react-router-dom"
 import { Authorized } from "./components/views/Authorized"

--- a/src/components/Hotcakes.css
+++ b/src/components/Hotcakes.css
@@ -12,12 +12,6 @@ textarea {
   line-height: 1.5;
 }
 
-/* commented this out to stop it from interferring with spacing styles on other pages */ 
-
-/* body {
-    padding: 0 3rem;
-} */
-
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Shrikhand', cursive;
   letter-spacing: 2px;

--- a/src/components/auth/Login.css
+++ b/src/components/auth/Login.css
@@ -92,7 +92,7 @@ fieldset {
 /* styes for the "yes, I want to be a member!" checkbox from Register.js */ 
 
 #isMember {
-    accent-color: #f5c46d;
+    accent-color: #944c0f;
 }
 
 .button--close {

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -3,10 +3,16 @@ import { Link } from "react-router-dom";
 import { useNavigate } from "react-router-dom"
 import "./Login.css"
 
-// IMPORTANT NOTE 
-// ideally, each user that logins will have their own unique cart to fill with orders 
-// that cart should also be empty 
+/* this component creates the login page where the user signs in to access the app */ 
+/* the component shares a style sheet with the register page, "Login.css", although there are some global styles that it inherits from Hotcakes.css */ 
+
+// on the login page, there will be an "email address" input field and a "login" button 
+// after filling out the "emali address" form field and clicking the "Login" button, the user will enter the app 
+
+// ideally, each user that signs in will have their own unique cart to fill with menu orders 
+// the cart that is created should be empty at first 
 // so we created a function called "createNewCartForUser" that creates an object with properties called "newCartForUser"
+// the user is also automatically taken to the "home" page one logged in
 
 export const Login = () => {
     const [email, set] = useState("rosered@me.com")
@@ -75,13 +81,13 @@ export const Login = () => {
                     </fieldset>
                     <fieldset>
                         <button type="submit" className="user-button">
-                            Sign In
+                            Login
                         </button>
                     </fieldset>
                 </form>
             </section>
             <section className="link--register">
-                <Link to="/register">Not a member yet?</Link>
+                <Link to="/register">Need to register?</Link>
             </section>
         </main>
     )

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -3,6 +3,15 @@ import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import "./Login.css"
 
+/* this component creates the register page where a vistor can sign up to be a user and access the app */ 
+/* the component shares a style sheet with the login page, "Login.css", although there are some global styles that it inherits from Hotcakes.css */ 
+
+// once the newly created user has an id that can be identified by the API/database, a new cart is created for them 
+// the new cart is also registerd with the API/database 
+
+// once registered as a user, they can login through the login page from now on 
+// each visitor that signs up as a user must use a unique email address; duplicate email addresses now allowed 
+
 export const Register = (props) => {
     const [customer, setCustomer] = useState({
         email: "",

--- a/src/components/cart/Cart.css
+++ b/src/components/cart/Cart.css
@@ -6,6 +6,8 @@
     padding: 0 3rem;
 }
 
+/* styles the "cart" title */ 
+
 .cart__title {
     font-size: 65px ; 
     color: #f5c46d; 
@@ -16,9 +18,12 @@
     padding: 0px; 
 }
 
+/* styles the "classic menu orders", "secret menu orders", and "custom menu orders" headings */ 
+
 .cart-menu-heading {
     color: #d57a17;
     text-shadow: 0px 0px 0px #944c0f; 
+    font-size: 25px; 
 }
 
 /* styles for the "Order" heading */ 
@@ -175,3 +180,4 @@
     margin: 25px 0px 15px 0px;
 
 }
+

--- a/src/components/cart/Cart.js
+++ b/src/components/cart/Cart.js
@@ -76,9 +76,8 @@ export const Cart = () => {
     // when the "delete order" button is clicked, the order is removed from the page and the API database is udpated
 
     /* below is a function that will refresh the page after any single custom order is deleted */ 
-    /* the function is called in the last .then of the custom order function */ 
-    /* this is helpful if the user has added more than one custom order to the cart page and needs to delete an order */ 
-    /* when a custom order is deleted and the order is deleted, the page will refresh, so the remaning orders are shown immediately    */ 
+    /* the function is called in the last .then of the classic menu, secret menu, and custom order functions */ 
+    /* this should help ensure that the page regenerates after each delete and show  */ 
 
     function refreshPage() {
         window.location.reload(false)
@@ -117,6 +116,7 @@ export const Cart = () => {
                                                         setMenuOrders(menuOrdersArray)
                                                     })
                                             })
+                                            .then(refreshPage)
                                     }}
                                     className="cart-delete-button">
                                     Delete Order
@@ -155,6 +155,7 @@ export const Cart = () => {
                                                         setSecretMenuOrders(secretMenuOrdersArray)
                                                     })
                                             })
+                                            .then(refreshPage)
                                     }}
                                     className="cart-delete-button">
                                     Delete Order

--- a/src/components/checkout/Checkout.js
+++ b/src/components/checkout/Checkout.js
@@ -10,7 +10,7 @@ export const Checkout = () => {
         <div className="checkout_page">
 
             <h1 className="checkout__title">Checkout</h1>
-            <p className="checkout-instructions">You're close to pancake paradise! </p>
+            <p className="checkout-instructions">Thank you for brunching with us. You're close to pancake paradise! </p>
             <p className="checkout-instructions">Please click the button below to complete payment, and then we'll start making your stack of heavenly hotcakes.</p>
 
             <div className="paypal_image">

--- a/src/components/custom/CustomMenu.css
+++ b/src/components/custom/CustomMenu.css
@@ -141,6 +141,45 @@ select {
     margin: 6px 10px 2px 10px;
 }
 
+/* styles for a feedback message that displays when the user clicks the "add to cart" button */ 
+
+.feedback {
+    border: 1px dotted cadetblue;
+    padding: 1rem;
+    background-color: rgb(218, 230, 247);
+    position: absolute;
+    top: 20%;
+    left: 50%;
+    width: 70%;
+    transform: translate(-50%, -50%);
+    animation: 1s slideDown;
+  }
+  
+  .invisible {
+    display: none;
+  }
+  
+  .visible {
+    display: block;
+  }
+  
+  .error {
+    border: 1px dotted rgb(107, 21, 4);
+    padding: 1rem;
+    background-color: rgb(255, 229, 228);
+  }
+  
+  @keyframes slideDown {
+    0% {
+      top: 0%;
+    }
+  
+    100% {
+      top: 20%;
+    }
+  }
+
+
 /* styles for the "save edit" button AND the press-down animation when the button is clicked */
 
 #custom-menu-save-button {

--- a/src/components/custom/CustomMenu.js
+++ b/src/components/custom/CustomMenu.js
@@ -72,6 +72,18 @@ export const CustomMenu = () => {
         []
     )
 
+     // when the user has clicked the "add to cart" button, a feedback message appears to confirm this was successful 
+
+    const [feedback, setFeedback] = useState("")
+
+    useEffect(() => {
+        if (feedback !== "") {
+            // Clear feedback to make entire element disappear after 3 seconds
+            setTimeout(() => setFeedback(""), 3000);
+        }
+    }, [feedback])
+
+
     const handleSaveButtonClick = (event) => {
         event.preventDefault()
 
@@ -109,12 +121,18 @@ export const CustomMenu = () => {
                     })
                 }
             })
+            .then(() => {
+                setFeedback(" ✨ Your order has been added to your cart! ")
+            })
     }
 
     return <>
 
-        <form className="custom_menu">
+        <div className={`${feedback.includes("Error") ? "error" : "feedback"} ${feedback === "" ? "invisible" : "visible"}`}>
+            {feedback}
+        </div>
 
+        <form className="custom_menu">
             <div className="custom_title_and_tagline_container">
                 <h1 className="custom__title">Custom Menu</h1>
                 <p className="custom_instructions">Build your own stack of pancakes!</p>
@@ -209,10 +227,8 @@ export const CustomMenu = () => {
             <button
                 onClick={(clickEvent) => handleSaveButtonClick(clickEvent)}
                 className="btn btn-primary" id="custom-menu-cart-button">
-                Add To Cart 
+                Add To Cart
             </button>
-
-
         </form>
     </>
 }

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -100,7 +100,45 @@ input {
     margin: 6px 10px 2px 10px;
 }
 
-/* styles for the "save edit" button AND the press-down animation when the button is clicked */
+/* styles for a feedback message that displays when the user clicks the "add to cart" button */ 
+
+.feedback {
+    border: 1px dotted cadetblue;
+    padding: 1rem;
+    background-color: rgb(218, 230, 247);
+    position: absolute;
+    top: 20%;
+    left: 50%;
+    width: 70%;
+    transform: translate(-50%, -50%);
+    animation: 1s slideDown;
+  }
+  
+  .invisible {
+    display: none;
+  }
+  
+  .visible {
+    display: block;
+  }
+  
+  .error {
+    border: 1px dotted rgb(107, 21, 4);
+    padding: 1rem;
+    background-color: rgb(255, 229, 228);
+  }
+  
+  @keyframes slideDown {
+    0% {
+      top: 0%;
+    }
+  
+    100% {
+      top: 20%;
+    }
+  }
+
+/* styles for the "save edit" button, from MenuEdit.js, AND the press-down animation when the button is clicked */
 
 #classic-menu-save-button {
     color: #bba1d0;

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,18 +1,24 @@
 import { useEffect, useState } from "react"
-import "./Menu.css"  
+import "./Menu.css"
+
+/* note: this component creates the "classic menu" form */
+/* the component has it's own style sheet, "Menu.css", although there are some global styles that it inherits from Hotcakes.css */
 
 export const Menu = () => {
 
-    // we made a cart object for local storage, so each user gets a cart as soon as they login
+    // we made a cart object for local storage, so each user gets a "cart" as soon as they login
+    // ultimately, the cart is what will hold and display the user's choies from the menu 
     // see Login.js for more context if needed 
 
     const localCart = localStorage.getItem("cart")
     const hotcakesCartObject = JSON.parse(localCart)
 
     // got a initial state variable to render the menu form, which has radio buttons to let users to make their choices
-    // we're fetching the menu items to display for the user when they see the form
+    // we have an array of objects called "menuItems". each object is an menu item that a user can choose. 
+    // we're fetching the objects from the "menuItems" array in the API/database and displaying them for the user on the page 
+    // we're looping through each menuItem object using .map and displaying each one's name and price as a radio button option
 
-    // then when the user starts clicking the radio buttons, the state is changing
+    // when the user clicks the radio buttons, the state is changing
     // so using the onChange event listener, see below in form, we're copying the initial state and modifying it 
 
     const [menuItems, setMenuItems] = useState([])
@@ -28,14 +34,30 @@ export const Menu = () => {
         []
     )
 
+     // when the user has clicked the "add to cart" button, a feedback message appears to confirm this was successful 
+
+    const [feedback, setFeedback] = useState("")
+
+    useEffect(() => {
+        if (feedback !== "") {
+            // Clear feedback to make entire element disappear after 3 seconds
+            setTimeout(() => setFeedback(""), 3000);
+        }
+    }, [feedback])
+
     // next, save the user's choices to permanent state though... 
-    // do this by using a POST request to store the user's choices to the API
+    // do this by using a POST request to store the user's choices in the API/database 
     // *** reminder, goal is to have the order or what the user submitted appear on the cart page 
-    // we have a join table in our ERD to make this work 
-    // "menuItemChoices" holds the user's choices
-    // must send to "menuOrders" table (id, menuItemId, and cartId)  
-    // so to make sure the menuItem info is carried over, we need to fetch on this and expand into menuOrders
+    // i have a join table in my ERD to make this work 
+
+    // "menuItemChoices" holds the data for which radio buttons the user clicked 
+    // send to "menuOrders" table (id, menuItemId, and cartId), which will be fetched from later to display on the cart page
+    // for now, to make sure the menuItem info is carried over, we need to FETCH on this and EXPAND into menuOrders
     // *** lets you add more than once item from the same menu to the cart; click cart button each time after making a choice 
+
+    // the user selects an item from the menu by cliking and filling in a radio button
+    // when they click the "add to cart" button, their choices are POSTED to the API/database for later reference 
+    // the hanleSaveButtonClick function and POST method are handling this piece 
 
     const [menuItemChoices, setMenuItemChoices] = useState({})
 
@@ -57,9 +79,19 @@ export const Menu = () => {
         })
             .then(response => response.json())
             .then(() => { })
+            .then(() => {
+                setFeedback(" ✨ Your order has been added to your cart! ")
+            })
     }
 
+    // the jsx renders the menu form for the user on the page
+    // once the user has clicked the "add to cart" button, a feedback message appears and confirms this. 
+
     return <>
+
+        <div className={`${feedback.includes("Error") ? "error" : "feedback"} ${feedback === "" ? "invisible" : "visible"}`}>
+            {feedback}
+        </div>
 
         <form className="classic_menu">
             <h1 className="classic__title">Classic Menu</h1>

--- a/src/components/nav/GuestNav.js
+++ b/src/components/nav/GuestNav.js
@@ -47,7 +47,7 @@ export const GuestNav = () => {
                 //                     localStorage.removeItem("cart")
                 //                     navigate("/", { replace: true })
                 //                 })
-                //         }}>LOGOUT</Link>
+                //         }}>SIGN OUT</Link>
                 //     </li>
                 //     : ""
             }

--- a/src/components/secret/SecretMenu.css
+++ b/src/components/secret/SecretMenu.css
@@ -102,6 +102,44 @@ input {
     margin: 6px 10px 2px 10px;
 }
 
+/* styles for a feedback message that displays when the user clicks the "add to cart" button */ 
+
+.feedback {
+    border: 1px dotted cadetblue;
+    padding: 1rem;
+    background-color: rgb(218, 230, 247);
+    position: absolute;
+    top: 20%;
+    left: 50%;
+    width: 70%;
+    transform: translate(-50%, -50%);
+    animation: 1s slideDown;
+  }
+  
+  .invisible {
+    display: none;
+  }
+  
+  .visible {
+    display: block;
+  }
+  
+  .error {
+    border: 1px dotted rgb(107, 21, 4);
+    padding: 1rem;
+    background-color: rgb(255, 229, 228);
+  }
+  
+  @keyframes slideDown {
+    0% {
+      top: 0%;
+    }
+  
+    100% {
+      top: 20%;
+    }
+  }
+
 /* styles for the "save edit" button AND the press-down animation when the button is clicked */
 
 #secret-menu-save-button {

--- a/src/components/secret/SecretMenu.js
+++ b/src/components/secret/SecretMenu.js
@@ -1,19 +1,25 @@
 
 import { useEffect, useState } from "react"
-import "./SecretMenu.css"  
+import "./SecretMenu.css"
+
+/* note: this component, which creates the "secret menu" form, works exactly like the " (classic) menu" component */
+/* the component has it's own style sheet, "SecretMenu.css", although there are also some global styles that it inherits from Hotcakes.css */
 
 export const SecretMenu = () => {
 
-    // we made a cart object for local storage, so each user gets a cart as soon as they login
+    // we made a cart object for local storage, so each user gets a "cart" as soon as they login
+    // ultimately, the cart is what will hold and display the user's choies from the menu 
     // see Login.js for more context if needed 
 
     const localCart = localStorage.getItem("cart")
     const hotcakesCartObject = JSON.parse(localCart)
 
-    // got a initial state variable to render the secret menu form, which has radio buttons to let users to make their choices
-    // we're fetching the sercret menu items to display for the user when they see the form
+    // got a initial state variable to render the menu form, which has radio buttons to let users to make their choices
+    // we have an array of objects called "secretMenuItems". each object is an menu item that a user can choose. 
+    // we're fetching the objects from the "secretMenuItems" array in the API/database and displaying them for the user on the page 
+    // we're looping through each secretMenuItem object using .map and displaying each one's name and price as a radio button option
 
-    // then when the user starts clicking the radio buttons, the state is changing
+    // when the user clicks the radio buttons, the state is changing
     // so using the onChange event listener, see below in form, we're copying the initial state and modifying it 
 
     const [secretMenuItems, setSecretMenuItems] = useState([])
@@ -29,14 +35,31 @@ export const SecretMenu = () => {
         []
     )
 
+    // when the user has clicked the "add to cart" button, a feedback message appears to confirm this was successful 
+
+    const [feedback, setFeedback] = useState("")
+
+    useEffect(() => {
+        if (feedback !== "") {
+            // Clear feedback to make entire element disappear after 3 seconds
+            setTimeout(() => setFeedback(""), 3000);
+        }
+    }, [feedback])
+
+
     // next, save the user's choices to permanent state though... 
     // do this by using a POST request to store the user's choices to the API
     // *** reminder, goal is to have the order or what the user submitted appear on the cart page 
-    // we have a join table in our ERD to make this work 
+    // i have a join table in our ERD to make this work 
+
     // "secretMenuItemChoices" holds the user's choices
     // must send to "secretMenuOrders" table (id, secretMenuItemId, and cartId)  
-    // so to make sure the secretMenuItem info is carried over, we need to fetch on this and expand into menuOrders
+    // so to make sure the secretMenuItem info is carried over, we need to FETCH on this and EXPAND into secretMenuOrders
     // *** lets you add more than once item from the same menu to the cart; click cart button each time after making a choice 
+
+    // the user selects an item from the secret menu by cliking and filling in a radio button
+    // when they click the "add to cart" button, their choices are POSTED to the API/database for later reference 
+    // the hanleSaveButtonClick function and POST method are handling this piece 
 
     const [secretMenuItemChoices, setSecretMenuItemChoices] = useState({})
 
@@ -58,9 +81,16 @@ export const SecretMenu = () => {
         })
             .then(response => response.json())
             .then(() => { })
+            .then(() => {
+                setFeedback(" ✨ Your order has been added to your cart! ")
+            })
     }
 
     return <>
+
+        <div className={`${feedback.includes("Error") ? "error" : "feedback"} ${feedback === "" ? "invisible" : "visible"}`}>
+            {feedback}
+        </div>
 
         <form className="secret_menu">
             <h1 className="secret__title">Secret Menu</h1>

--- a/src/components/secret/SecretMenuEdit.js
+++ b/src/components/secret/SecretMenuEdit.js
@@ -4,7 +4,7 @@ import "./SecretMenu.css"
 
 export const SecretMenuEdit = () => {
 
-    // we have an initial state variable to render the menu form, which has radio buttons to let users to make their choices
+    // we have an initial state variable to render the menu form from Menu.js,
     // we're fetching the objects from "menuItems" to display for the user when they see the form
     // then when the user starts clicking the radio buttons, the state is changing
     // so using the onChange event listener, see below in form, we're copying the initial state and modifying it 
@@ -12,8 +12,7 @@ export const SecretMenuEdit = () => {
     const [secretMenuItems, setSecretMenuItems] = useState([])
 
     // this is to edit the user's selections later in the cart 
-    // *** remember to change the URL in the PUT fetch request to target a specific thing 
-    // have this target an id like http://localhost:8088/menuOrders/${menuOrder.id}
+    // *** remember, the URL in the PUT fetch request must target a specific thing 
 
     const [secretMenuItemChoices, setSecretMenuItemChoices] = useState({
         id: 0,

--- a/src/index.js
+++ b/src/index.js
@@ -17,4 +17,5 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+
 reportWebVitals();

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,5 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
+
 import '@testing-library/jest-dom';


### PR DESCRIPTION
for the cart page, did some more testing and found that there are additional scenarios where a single classic, secret, or custom order can be deleted and ALL orders are removed from the page as a result. as seen in the original scenario, the remaining orders are still present. the page just needs a manual refresh to show them.

i added a refresh function for the classic menu and secret menus, but this doesn't seem to solve the problem fully. will need to do more testing and try additional solutions. for right now, be careful of having more than one custom order in the cart. this seems to be when the issue appears most. 

silver lining, did successfully create feedback messages for users. these will act as a confirmation that their selection was recorded and display after the user clicks the "add to cart" button for any of the menus.  needs additional styling, but function is in place. 